### PR TITLE
[bzip2] Initial implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["bufread", "stream", "brotli", "deflate", "gzip", "zlib", "zstd"]
+default = ["bufread", "stream", "brotli", "bzip", "deflate", "gzip", "zlib", "zstd"]
 bufread = ["futures-io-preview"]
 stream = ["bytes"]
 brotli = ["brotli2"]
+bzip = ["bzip2"]
 deflate = ["flate2"]
 gzip = ["flate2"]
 zlib = ["flate2"]
@@ -28,6 +29,7 @@ zstd = ["libzstd", "zstd-safe"]
 [dependencies]
 brotli2 = { version = "0.3.2", optional = true }
 bytes = { version = "0.4.12", optional = true }
+bzip2 = { version = "0.3.3" , optional = true }
 flate2 = { version = "1.0.11", optional = true }
 futures-core-preview = { version = "0.3.0-alpha.19", default-features = false }
 futures-io-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["std"], optional = true }

--- a/src/bufread/bzip2.rs
+++ b/src/bufread/bzip2.rs
@@ -1,0 +1,24 @@
+use bzip2::Compression;
+use futures_io::AsyncBufRead;
+
+decoder! {
+    /// A bzip2 decoder, or decompressor.
+    #[cfg_attr(docsrs, doc(cfg(feature = "bzip")))]
+    BzDecoder
+}
+
+encoder! {
+    /// A bzip2 encoder, or compressor.
+    #[cfg_attr(docsrs, doc(cfg(feature = "bzip")))]
+    BzEncoder
+}
+
+impl<R: AsyncBufRead> BzEncoder<R> {
+    /// Creates a new encoder which will read uncompressed data from the given stream and emit a
+    /// compressed stream.
+    pub fn new(read: R, level: Compression) -> BzEncoder<R> {
+        BzEncoder {
+            inner: crate::bufread::Encoder::new(read, crate::codec::BzEncoder::new(level, 30)),
+        }
+    }
+}

--- a/src/bufread/mod.rs
+++ b/src/bufread/mod.rs
@@ -7,6 +7,8 @@ mod macros;
 
 #[cfg(feature = "brotli")]
 mod brotli;
+#[cfg(feature = "bzip")]
+mod bzip2;
 #[cfg(feature = "deflate")]
 mod deflate;
 #[cfg(feature = "gzip")]
@@ -20,6 +22,8 @@ pub(crate) use generic::{Decoder, Encoder};
 
 #[cfg(feature = "brotli")]
 pub use self::brotli::{BrotliDecoder, BrotliEncoder};
+#[cfg(feature = "bzip")]
+pub use self::bzip2::{BzDecoder, BzEncoder};
 #[cfg(feature = "deflate")]
 pub use self::deflate::{DeflateDecoder, DeflateEncoder};
 #[cfg(feature = "gzip")]

--- a/src/codec/bzip2/decoder.rs
+++ b/src/codec/bzip2/decoder.rs
@@ -1,0 +1,80 @@
+use crate::{codec::Decode, util::PartialBuffer};
+use std::fmt;
+use std::io::{Error, ErrorKind, Result};
+
+use bzip2::{Decompress, Status};
+
+pub struct BzDecoder {
+    decompress: Decompress,
+}
+
+impl fmt::Debug for BzDecoder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "BzDecoder {{total_in: {}, total_out: {}}}",
+            self.decompress.total_in(),
+            self.decompress.total_out()
+        )
+    }
+}
+
+impl BzDecoder {
+    pub(crate) fn new() -> Self {
+        Self {
+            decompress: Decompress::new(false),
+        }
+    }
+
+    fn decode(
+        &mut self,
+        input: &mut PartialBuffer<&[u8]>,
+        output: &mut PartialBuffer<&mut [u8]>,
+    ) -> Result<Status> {
+        let prior_in = self.decompress.total_in();
+        let prior_out = self.decompress.total_out();
+
+        let status = self
+            .decompress
+            .decompress(input.unwritten(), output.unwritten_mut())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+        input.advance((self.decompress.total_in() - prior_in) as usize);
+        output.advance((self.decompress.total_out() - prior_out) as usize);
+
+        Ok(status)
+    }
+}
+
+impl Decode for BzDecoder {
+    fn decode(
+        &mut self,
+        input: &mut PartialBuffer<&[u8]>,
+        output: &mut PartialBuffer<&mut [u8]>,
+    ) -> Result<bool> {
+        match self.decode(input, output)? {
+            // Decompression went fine, nothing much to report.
+            Status::Ok => Ok(false),
+
+            // The Flush action on a compression went ok.
+            Status::FlushOk => unreachable!(),
+
+            // THe Run action on compression went ok.
+            Status::RunOk => unreachable!(),
+
+            // The Finish action on compression went ok.
+            Status::FinishOk => unreachable!(),
+
+            // The stream's end has been met, meaning that no more data can be input.
+            Status::StreamEnd => Ok(true),
+
+            // There was insufficient memory in the input or output buffer to complete
+            // the request, but otherwise everything went normally.
+            Status::MemNeeded => Err(Error::new(ErrorKind::Other, "out of memory")),
+        }
+    }
+
+    fn finish(&mut self, _output: &mut PartialBuffer<&mut [u8]>) -> Result<bool> {
+        Ok(true)
+    }
+}

--- a/src/codec/bzip2/encoder.rs
+++ b/src/codec/bzip2/encoder.rs
@@ -1,0 +1,120 @@
+use crate::{codec::Encode, util::PartialBuffer};
+use std::fmt;
+use std::io::{Error, ErrorKind, Result};
+
+use bzip2::{Action, Compress, Compression, Status};
+
+pub struct BzEncoder {
+    compress: Compress,
+}
+
+impl fmt::Debug for BzEncoder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "BzEncoder {{total_in: {}, total_out: {}}}",
+            self.compress.total_in(),
+            self.compress.total_out()
+        )
+    }
+}
+
+impl BzEncoder {
+    /// Creates a new stream prepared for compression.
+    ///
+    /// The `work_factor` parameter controls how the compression phase behaves
+    /// when presented with worst case, highly repetitive, input data. If
+    /// compression runs into difficulties caused by repetitive data, the
+    /// library switches from the standard sorting algorithm to a fallback
+    /// algorithm. The fallback is slower than the standard algorithm by perhaps
+    /// a factor of three, but always behaves reasonably, no matter how bad the
+    /// input.
+    ///
+    /// Lower values of `work_factor` reduce the amount of effort the standard
+    /// algorithm will expend before resorting to the fallback. You should set
+    /// this parameter carefully; too low, and many inputs will be handled by
+    /// the fallback algorithm and so compress rather slowly, too high, and your
+    /// average-to-worst case compression times can become very large. The
+    /// default value of 30 gives reasonable behaviour over a wide range of
+    /// circumstances.
+    ///
+    /// Allowable values range from 0 to 250 inclusive. 0 is a special case,
+    /// equivalent to using the default value of 30.
+    pub(crate) fn new(level: Compression, work_factor: u32) -> Self {
+        Self {
+            compress: Compress::new(level, work_factor),
+        }
+    }
+
+    fn encode(
+        &mut self,
+        input: &mut PartialBuffer<&[u8]>,
+        output: &mut PartialBuffer<&mut [u8]>,
+        action: Action,
+    ) -> Result<Status> {
+        let prior_in = self.compress.total_in();
+        let prior_out = self.compress.total_out();
+
+        let status = self
+            .compress
+            .compress(input.unwritten(), output.unwritten_mut(), action)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+        input.advance((self.compress.total_in() - prior_in) as usize);
+        output.advance((self.compress.total_out() - prior_out) as usize);
+
+        Ok(status)
+    }
+}
+
+impl Encode for BzEncoder {
+    fn encode(
+        &mut self,
+        input: &mut PartialBuffer<&[u8]>,
+        output: &mut PartialBuffer<&mut [u8]>,
+    ) -> Result<()> {
+        match self.encode(input, output, Action::Run)? {
+            // Decompression went fine, nothing much to report.
+            Status::Ok => Ok(()),
+
+            // The Flush action on a compression went ok.
+            Status::FlushOk => unreachable!(),
+
+            // The Run action on compression went ok.
+            Status::RunOk => Ok(()),
+
+            // The Finish action on compression went ok.
+            Status::FinishOk => unreachable!(),
+
+            // The stream's end has been met, meaning that no more data can be input.
+            Status::StreamEnd => unreachable!(),
+
+            // There was insufficient memory in the input or output buffer to complete
+            // the request, but otherwise everything went normally.
+            Status::MemNeeded => Err(Error::new(ErrorKind::Other, "out of memory")),
+        }
+    }
+
+    fn finish(&mut self, output: &mut PartialBuffer<&mut [u8]>) -> Result<bool> {
+        match self.encode(&mut PartialBuffer::new(&[][..]), output, Action::Finish)? {
+            // Decompression went fine, nothing much to report.
+            Status::Ok => Ok(false),
+
+            // The Flush action on a compression went ok.
+            Status::FlushOk => unreachable!(),
+
+            // The Run action on compression went ok.
+            Status::RunOk => unreachable!(),
+
+            // The Finish action on compression went ok.
+            Status::FinishOk => Ok(false),
+
+            // The stream's end has been met, meaning that no more data can be input.
+            Status::StreamEnd => Ok(true),
+
+            // There was insufficient memory in the input or output buffer to complete
+            // the request, but otherwise everything went normally.
+            Status::MemNeeded => Err(Error::new(ErrorKind::Other, "out of memory")),
+        }
+    }
+}

--- a/src/codec/bzip2/mod.rs
+++ b/src/codec/bzip2/mod.rs
@@ -1,0 +1,4 @@
+mod decoder;
+mod encoder;
+
+pub(crate) use self::{decoder::BzDecoder, encoder::BzEncoder};

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -3,6 +3,8 @@ use std::io::Result;
 
 #[cfg(feature = "brotli")]
 mod brotli;
+#[cfg(feature = "bzip2")]
+mod bzip2;
 #[cfg(feature = "deflate")]
 mod deflate;
 #[cfg(feature = "flate2")]
@@ -16,6 +18,8 @@ mod zstd;
 
 #[cfg(feature = "brotli")]
 pub(crate) use self::brotli::{BrotliDecoder, BrotliEncoder};
+#[cfg(feature = "bzip2")]
+pub(crate) use self::bzip2::{BzDecoder, BzEncoder};
 #[cfg(feature = "deflate")]
 pub(crate) use self::deflate::{DeflateDecoder, DeflateEncoder};
 #[cfg(feature = "flate2")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //! choices, these determine which types will be available inside the above modules:
 //!
 //!  * `brotli`
+//!  * `bzip2`
 //!  * `deflate`
 //!  * `gzip`
 //!  * `zlib`
@@ -62,5 +63,11 @@ pub mod brotli2 {
     pub use brotli2::CompressParams;
 }
 
+/// Types to configure [`bzip2`](::bzip2) based encoders.
+#[cfg(feature = "bzip")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bzip")))]
+pub mod bzip2 {
+    pub use bzip2::Compression;
+}
 mod unshared;
 mod util;

--- a/src/stream/bzip2.rs
+++ b/src/stream/bzip2.rs
@@ -1,0 +1,29 @@
+use bytes::Bytes;
+use bzip2::Compression;
+use futures_core::stream::Stream;
+use std::io::Result;
+
+decoder! {
+    /// A bzip2 decoder, or decompressor.
+    #[cfg_attr(docsrs, doc(cfg(feature = "bzip")))]
+    BzDecoder
+}
+
+encoder! {
+    /// A bzip2 encoder, or compressor.
+    #[cfg_attr(docsrs, doc(cfg(feature = "bzip")))]
+    BzEncoder
+}
+
+impl<S: Stream<Item = Result<Bytes>>> BzEncoder<S> {
+    /// Creates a new encoder which will read uncompressed data from the given stream and emit a
+    /// compressed stream.
+    pub fn new(stream: S, level: Compression) -> Self {
+        Self {
+            inner: crate::stream::generic::Encoder::new(
+                stream,
+                crate::codec::BzEncoder::new(level, 30),
+            ),
+        }
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -14,6 +14,8 @@ mod macros;
 
 #[cfg(feature = "brotli")]
 mod brotli;
+#[cfg(feature = "bzip")]
+mod bzip2;
 #[cfg(feature = "deflate")]
 mod deflate;
 #[cfg(feature = "gzip")]
@@ -27,6 +29,8 @@ pub(crate) use self::generic::{Decoder, Encoder};
 
 #[cfg(feature = "brotli")]
 pub use self::brotli::{BrotliDecoder, BrotliEncoder};
+#[cfg(feature = "bzip")]
+pub use self::bzip2::{BzDecoder, BzEncoder};
 #[cfg(feature = "deflate")]
 pub use self::deflate::{DeflateDecoder, DeflateEncoder};
 #[cfg(feature = "gzip")]

--- a/tests/bzip2.rs
+++ b/tests/bzip2.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+mod utils;
+
+test_cases!(bzip2::{bufread::{compress, decompress}, stream::{compress, decompress}});

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -58,4 +58,4 @@ macro_rules! tests {
     }
 }
 
-tests!(brotli, deflate, gzip, zlib, zstd);
+tests!(brotli, bzip2, deflate, gzip, zlib, zstd);

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -137,6 +137,54 @@ pub mod brotli {
     }
 }
 
+pub mod bzip2 {
+    pub mod sync {
+        use crate::utils::prelude::*;
+
+        pub fn compress(bytes: &[u8]) -> Vec<u8> {
+            use bzip2::{bufread::BzEncoder, Compression};
+            read_to_vec(BzEncoder::new(bytes, Compression::Fastest))
+        }
+
+        pub fn decompress(bytes: &[u8]) -> Vec<u8> {
+            use bzip2::bufread::BzDecoder;
+            read_to_vec(BzDecoder::new(bytes))
+        }
+    }
+
+    pub mod stream {
+        use crate::utils::prelude::*;
+
+        pub fn compress(input: impl Stream<Item = io::Result<Bytes>>) -> Vec<u8> {
+            use async_compression::{bzip2::Compression, stream::BzEncoder};
+            pin_mut!(input);
+            stream_to_vec(BzEncoder::new(input, Compression::Fastest))
+        }
+
+        pub fn decompress(input: impl Stream<Item = io::Result<Bytes>>) -> Vec<u8> {
+            use async_compression::stream::BzDecoder;
+            pin_mut!(input);
+            stream_to_vec(BzDecoder::new(input))
+        }
+    }
+
+    pub mod bufread {
+        use crate::utils::prelude::*;
+
+        pub fn compress(input: impl AsyncBufRead) -> Vec<u8> {
+            use async_compression::{bufread::BzEncoder, bzip2::Compression};
+            pin_mut!(input);
+            async_read_to_vec(BzEncoder::new(input, Compression::Fastest))
+        }
+
+        pub fn decompress(input: impl AsyncBufRead) -> Vec<u8> {
+            use async_compression::bufread::BzDecoder;
+            pin_mut!(input);
+            async_read_to_vec(BzDecoder::new(input))
+        }
+    }
+}
+
 pub mod deflate {
     pub mod sync {
         use crate::utils::prelude::*;


### PR DESCRIPTION
This is an attempt to add bzip2 support to this library. It's at RFC stage, since a few unreleased  bzip2 changes are still needed, c.f. https://github.com/alexcrichton/bzip2-rs/pull/49. 

EDIT: It now works with the latest stable version

## Description
Since flate and bzip2 crates are quite similar, I used that as a basis for the implementation. Only details are different.

## How Has This Been Tested?
I added a test case. It still fails, but I'm not entirely sure why. Probably something is wrong at compression, since I can decompress just fine using the crate in a (still private) app. Maybe you have some more insight? 

EDIT: Tests pass fine :).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
